### PR TITLE
Fix for empty modified time

### DIFF
--- a/lzmadec.go
+++ b/lzmadec.go
@@ -135,7 +135,11 @@ func parseEntryLines(lines []string) (Entry, error) {
 				e.PackedSize, err = strconv.Atoi(v)
 			}
 		case "modified":
-			e.Modified, err = time.Parse(timeLayout, v)
+			if v != "" {
+				e.Modified, err = time.Parse(timeLayout, v)
+			} else {
+				e.Modified = time.Now()
+			}
 		case "attributes":
 			e.Attributes = v
 		case "crc":


### PR DESCRIPTION
----------
Path = Test.file
Size = 131072
Packed Size = 119856
Modified = 
Attributes = .....
CRC = 370A2C2F
Encrypted = -
Method = LZMA:19
Block = 0